### PR TITLE
fix: remove bad ","

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     {
       "name": "Mark Stosberg",
       "url": "https://mark.stosberg.com",
-      "email": "mark@rideamigos.com",
+      "email": "mark@rideamigos.com"
     }
   ],
   "homepage": "https://github.com/rideamigoscorp/authorized",
@@ -32,7 +32,7 @@
   },
   "files" : [
     "lib/*",
-    "*.js",
+    "*.js"
   ],
   "types": "lib/authorized.d.ts",
   "devDependencies": {


### PR DESCRIPTION
When upgrading to Node22 somehow parsing of package.json becomes more sensible. Removing the "," that are invalid in the JSON spec resolves the issue.